### PR TITLE
chore: force Node.js 24 for GitHub Actions

### DIFF
--- a/.github/workflows/cleanup-artifacts.yml
+++ b/.github/workflows/cleanup-artifacts.yml
@@ -14,6 +14,9 @@ on:
         required: false
         default: 'false'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   actions: write
   contents: write

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,6 +6,7 @@ on:
       - main
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 


### PR DESCRIPTION
## Changes
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to workflow environment sections

## Context
- Node.js 20 will become the default on GitHub Actions runners **June 2, 2026** (5 days away)
- Node.js 20 will be completely removed on **September 16, 2026**
- This change forces workflows to use Node.js 24 now to avoid deprecation warnings

## References
- [GitHub Blog: Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)